### PR TITLE
Add a bin/hack script to play with gem

### DIFF
--- a/bin/hack
+++ b/bin/hack
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "uber"
+
+require "irb"
+IRB.start

--- a/uber-sdk.gemspec
+++ b/uber-sdk.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/chrisenytc/uber-sdk"
   spec.license       = "MIT"
 
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.start_with?(".") || f =~ %r(^(spec|bin)/) }
   spec.require_paths = ["lib"]
   spec.required_rubygems_version = ">= 1.3.5"


### PR DESCRIPTION
You can now run `bin/hack` for an interactive prompt that will allow you to experiment.

Remove `spec.executable` since this gem does not provide a cli tool.
