### PR TITLE
Pack less files in released gem

### DIFF
--- a/uber-sdk.gemspec
+++ b/uber-sdk.gemspec
@@ -14,11 +14,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/chrisenytc/uber-sdk"
   spec.license       = "MIT"
 
-  spec.files = %w(LICENSE.txt README.md Rakefile uber-sdk.gemspec)
-  spec.files += Dir.glob("lib/**/*.rb")
-  spec.files += Dir.glob("test/**/*")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = Dir.glob("test/**/*")
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.start_with?(".") || f =~ %r(^(spec|bin)/) }
   spec.require_paths = ["lib"]
   spec.required_rubygems_version = ">= 1.3.5"
 


### PR DESCRIPTION
Rationale: bundler/bundler#3207
- don't pack hidden files
- don't pack test files (`spec/*`)
- don't pack `bin/*`
- pack these git tracking files
  
  ``` ruby
  > `git ls-files -z`.split("\x0").reject { |f| f.start_with?(".") || f =~ %r(^(spec|bin)/) }
  => ["Gemfile",
  "LICENSE.txt",
  "README.md",
  "Rakefile",
  "lib/uber.rb",
  "lib/uber/api.rb",
  "lib/uber/api/activities.rb",
  "lib/uber/api/me.rb",
  "lib/uber/api/price_estimates.rb",
  "lib/uber/api/products.rb",
  "lib/uber/api/promotions.rb",
  "lib/uber/api/requests.rb",
  "lib/uber/api/time_estimates.rb",
  "lib/uber/api_request.rb",
  "lib/uber/arguments.rb",
  "lib/uber/base.rb",
  "lib/uber/client.rb",
  "lib/uber/error.rb",
  "lib/uber/models/activity.rb",
  "lib/uber/models/estimate.rb",
  "lib/uber/models/map.rb",
  "lib/uber/models/price.rb",
  "lib/uber/models/product.rb",
  "lib/uber/models/promotion.rb",
  "lib/uber/models/request.rb",
  "lib/uber/models/time.rb",
  "lib/uber/models/user.rb",
  "lib/uber/parse_json.rb",
  "lib/uber/rate_limit.rb",
  "lib/uber/token.rb",
  "lib/uber/utils.rb",
  "lib/uber/version.rb",
  "uber-sdk.gemspec"]
  ```
